### PR TITLE
enhance: Add a unique color for each composable border and recomposition count text

### DIFF
--- a/jetpackperformancescanner/src/main/java/com/qamar/composescanner/TrackerModifier.kt
+++ b/jetpackperformancescanner/src/main/java/com/qamar/composescanner/TrackerModifier.kt
@@ -17,6 +17,16 @@ import androidx.compose.ui.unit.dp
 fun Modifier.trackRecompositions(): Modifier {
     val recompositionCount = remember { mutableStateOf(0) }
 
+
+    val colorsMap = remember { mutableMapOf<String, Color>() }
+
+    val uniqueModifierId = remember { Object().hashCode() }
+
+    val assignedColor = colorsMap.getOrPut(uniqueModifierId.toString()) {
+        generateRandomColor()
+    }
+
+
     // Use SideEffect to track recompositions (increments only once per recomposition)
     SideEffect {
         recompositionCount.value += 1
@@ -34,7 +44,7 @@ fun Modifier.trackRecompositions(): Modifier {
                         .Paint()
                         .apply {
                             textSize = 40f
-                            color = android.graphics.Color.RED
+                            color = assignedColor.toInt()
                             isAntiAlias = true
                         }
                     // Draw the recomposition count text below the content
@@ -47,6 +57,23 @@ fun Modifier.trackRecompositions(): Modifier {
                 }
             }
         )
-        .border(2.dp, Color.Red)
+        .border(2.dp, assignedColor)
         .padding(16.dp)
+}
+
+private fun generateRandomColor(): Color {
+    return Color(
+        red = (0..255).random() / 255f,
+        green = (0..255).random() / 255f,
+        blue = (0..255).random() / 255f,
+        alpha = 1f
+    )
+}
+
+private fun Color.toInt(): Int {
+    val alpha = (alpha * 255).toInt() and 0xFF
+    val red = (red * 255).toInt() and 0xFF
+    val green = (green * 255).toInt() and 0xFF
+    val blue = (blue * 255).toInt() and 0xFF
+    return (alpha shl 24) or (red shl 16) or (green shl 8) or blue
 }


### PR DESCRIPTION
**Summary**
This PR enhances the UI by automatically assigning a unique color to each composable element border based on unique Id. This allows for easily identifying different composables in the UI for better debugging and visual differentiation.

**Issue**
Closes #1 .

**Motivation**
In large or complex UIs, it can be difficult to visually differentiate between composables for debugging purposes. This enhancement assigns a unique color to each composable border and recomposition count text, allowing developers to track recompositions and identify elements more easily during UI development.

**Changes made**
Introduced a colors map where each composable border gets a unique color based on a unique Id.
The color is generated randomly for each composable on the first recomposition, ensuring that it remains consistent across recompositions.


**Considerations**
An assigned color for a composable border might be the same as the background color which make it invisible.
Color randomness implementation might result in visually indistinct or overly similar colors.

