### PR TITLE
Suggest a way to safely keep trackRecompositions modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Inspired by [React Scanner](https://t.co/jyqyMp9SZ4), this tool shows which comp
 - Real-time recomposition tracking: See when and how your composables are recomposed.
 - Live recomposition count: Each component that gets recomposed shows how many times it has been recomposed.
 - Visual feedback: Components that are recomposed are outlined with a red border, and their recomposition count is displayed.
+- Production-safe debugging: Use `trackRecompositionsIf()` to leave tracking in your codebase safely — no need to manually add or remove modifiers.
 
 # Demo
 
@@ -19,6 +20,32 @@ https://github.com/user-attachments/assets/6b540c1c-b3c0-455d-84dc-f6f1707416ea
 This tool uses the ```Modifier.trackRecompositions()``` to track recompositions. When a recomposition occurs, the component will display a red border, and the recomposition count will update.
 
 You can customize the ```trackRecompositions()``` modifier to track different UI components in your app and use this tool to debug and optimize your Jetpack Compose UI.
+
+#### Using `trackRecompositionsIf()`:
+No need to add and remove `trackRecompositions()` everytime you want to test. You can safely keep the code even in production.
+
+All you need to do is define this extension function in your project
+~~~kotlin
+/**
+ * Conditionally tracks recompositions of a Composable, useful for debugging in development.
+ *
+ * Usage:
+ * ```kotlin
+ * Modifier.trackRecompositionsIf()
+ * Modifier.trackRecompositionsIf(enabled = true)
+ * Modifier.trackRecompositionsIf(enabled = BuildConfig.DEBUG)
+ * ```
+ *
+ * @param enabled Whether recomposition tracking should be applied. Default is `false`.
+ * You can pass `BuildConfig.DEBUG` or use your own runtime flag.
+ *
+ * @return The original Modifier if disabled, or a recomposition-tracking Modifier if enabled.
+ */
+@Composable
+fun Modifier.trackRecompositionsIf(enabled: Boolean = false): Modifier {
+    return if (enabled) this.trackRecompositions() else this
+}
+~~~
 
 
 ## Contribution

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,4 +68,6 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    implementation(project(":jetpackperformancescanner"))
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.qamar.jetpackcomposscanner"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.qamar.jetpackcomposscanner"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 
@@ -39,6 +39,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"

--- a/app/src/main/java/com/qamar/jetpackcomposscanner/MainActivity.kt
+++ b/app/src/main/java/com/qamar/jetpackcomposscanner/MainActivity.kt
@@ -119,6 +119,20 @@ fun RecompositionItem(
     }
 }
 
+/**
+ * Conditionally tracks recompositions of a Composable, useful for debugging in development.
+ *
+ * Usage:
+ * ```kotlin
+ * Modifier.trackRecompositionsIf()
+ * Modifier.trackRecompositionsIf(enabled = true)
+ * ```
+ *
+ * @param enabled Whether recomposition tracking should be applied. Default is `false`.
+ * You can pass `BuildConfig.DEBUG` or use your own runtime flag.
+ *
+ * @return The original Modifier if disabled, or a recomposition-tracking Modifier if enabled.
+ */
 @Composable
 fun Modifier.trackRecompositionsIf(
     enabled: Boolean = FakeAppConfig.enableCompositionTracker

--- a/app/src/main/java/com/qamar/jetpackcomposscanner/MainActivity.kt
+++ b/app/src/main/java/com/qamar/jetpackcomposscanner/MainActivity.kt
@@ -27,6 +27,10 @@ import androidx.compose.ui.unit.dp
 import com.qamar.composescanner.trackRecompositions
 import com.qamar.jetpackcomposscanner.ui.theme.JetpackComposScannerTheme
 
+object FakeAppConfig {
+    val enableCompositionTracker: Boolean = true
+}
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -50,7 +54,7 @@ fun RecompositionTrackerScreen() {
             label = { Text("Enter item") },
             modifier = Modifier
                 .fillMaxWidth()
-                .trackRecompositions()
+                .trackRecompositionsIf()
         )
 
         Spacer(modifier = Modifier.height(28.dp))
@@ -71,7 +75,7 @@ private fun TrackButton(
     onClick: () -> Unit
 ) {
     Button(
-        onClick = onClick, modifier = Modifier.trackRecompositions()
+        onClick = onClick, modifier = Modifier.trackRecompositionsIf()
 
     ) {
         Text(
@@ -85,7 +89,7 @@ private fun List(items: SnapshotStateList<String>) {
     LazyColumn(
         modifier = Modifier
             .fillMaxWidth()
-            .trackRecompositions(),
+            .trackRecompositionsIf(),
         verticalArrangement = Arrangement.spacedBy(23.dp)
     ) {
         items(items, key = {
@@ -113,4 +117,11 @@ fun RecompositionItem(
             style = MaterialTheme.typography.bodyLarge
         )
     }
+}
+
+@Composable
+fun Modifier.trackRecompositionsIf(
+    enabled: Boolean = FakeAppConfig.enableCompositionTracker
+): Modifier {
+    return if (enabled) this.trackRecompositions() else this
 }

--- a/app/src/main/java/com/qamar/jetpackcomposscanner/MainActivity.kt
+++ b/app/src/main/java/com/qamar/jetpackcomposscanner/MainActivity.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,10 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.qamar.composescanner.trackRecompositions
 import com.qamar.jetpackcomposscanner.ui.theme.JetpackComposScannerTheme
-
-object FakeAppConfig {
-    val enableCompositionTracker: Boolean = true
-}
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -135,7 +130,7 @@ fun RecompositionItem(
  */
 @Composable
 fun Modifier.trackRecompositionsIf(
-    enabled: Boolean = FakeAppConfig.enableCompositionTracker
+    enabled: Boolean = BuildConfig.DEBUG
 ): Modifier {
     return if (enabled) this.trackRecompositions() else this
 }

--- a/jetpackperformancescanner/build.gradle.kts
+++ b/jetpackperformancescanner/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.qamar.jetpack_performance_scanner"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 24


### PR DESCRIPTION
### Why
Manually adding and removing trackRecompositions() during development is tedious and error-prone. This PR introduces a new extension function, trackRecompositionsIf(), which conditionally applies recomposition tracking based on a Boolean flag (e.g. BuildConfig.DEBUG, remote config, or any custom condition).

This approach allows developers to leave tracking code safely in production, while toggling it on/off via a single variable. It also makes it easier to test recomposition behavior in live environments without needing code changes.