### PR TITLE
📦 Publish Jetpack Compose Tracker v1.0.0 to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,50 +11,99 @@ Inspired by [React Scanner](https://t.co/jyqyMp9SZ4), this tool shows which comp
 - Visual feedback: Components that are recomposed are outlined with a red border, and their recomposition count is displayed.
 - Production-safe debugging: Use `trackRecompositionsIf()` to leave tracking in your codebase safely — no need to manually add or remove modifiers.
 
-# Demo
+## Demo
 
 https://github.com/user-attachments/assets/6b540c1c-b3c0-455d-84dc-f6f1707416ea
 
+## Installation
+
+Add the dependency to your app's `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("io.github.qamarelsafadi:compose-tracker:1.0.0")
+}
+```
+
+## Usage
+
+### Basic Tracking
+Use `trackRecompositions()` to track recompositions on any Composable:
+
+```kotlin
+@Composable
+fun MyComposable() {
+    Text(
+        text = "Hello World",
+        modifier = Modifier.trackRecompositions()
+    )
+}
+```
+
+### Production-Safe Tracking
+Use `trackRecompositionsIf()` for conditional tracking that's safe to leave in production:
+
+```kotlin
+@Composable
+fun MyComposable() {
+    Text(
+        text = "Hello World",
+        modifier = Modifier
+            .trackRecompositionsIf(BuildConfig.DEBUG) // Only in debug builds
+            .padding(16.dp)
+    )
+}
+```
+
+Available options:
+```kotlin
+// Always disabled (default)
+Modifier.trackRecompositionsIf()
+
+// Always enabled
+Modifier.trackRecompositionsIf(enabled = true)
+
+// Only in debug builds
+Modifier.trackRecompositionsIf(enabled = BuildConfig.DEBUG)
+
+// Custom condition
+Modifier.trackRecompositionsIf(enabled = isDebugging)
+```
 
 ## How It Works
-This tool uses the ```Modifier.trackRecompositions()``` to track recompositions. When a recomposition occurs, the component will display a red border, and the recomposition count will update.
 
-You can customize the ```trackRecompositions()``` modifier to track different UI components in your app and use this tool to debug and optimize your Jetpack Compose UI.
+This tool uses the `Modifier.trackRecompositions()` to track recompositions. When a recomposition occurs, the component will display a red border, and the recomposition count will update.
 
-#### Using `trackRecompositionsIf()`:
-No need to add and remove `trackRecompositions()` everytime you want to test. You can safely keep the code even in production.
-
-All you need to do is define this extension function in your project
-~~~kotlin
-/**
- * Conditionally tracks recompositions of a Composable, useful for debugging in development.
- *
- * Usage:
- * ```kotlin
- * Modifier.trackRecompositionsIf()
- * Modifier.trackRecompositionsIf(enabled = true)
- * Modifier.trackRecompositionsIf(enabled = BuildConfig.DEBUG)
- * ```
- *
- * @param enabled Whether recomposition tracking should be applied. Default is `false`.
- * You can pass `BuildConfig.DEBUG` or use your own runtime flag.
- *
- * @return The original Modifier if disabled, or a recomposition-tracking Modifier if enabled.
- */
-@Composable
-fun Modifier.trackRecompositionsIf(enabled: Boolean = false): Modifier {
-    return if (enabled) this.trackRecompositions() else this
-}
-~~~
-
+The library provides two main functions:
+- `trackRecompositions()`: Always tracks recompositions
+- `trackRecompositionsIf(enabled: Boolean)`: Conditionally tracks recompositions based on the enabled parameter
 
 ## Contribution
-If you’d like to contribute to this project, feel free to open issues, submit pull requests, or suggest new features. Here's how you can contribute:
+
+If you'd like to contribute to this project, feel free to open issues, submit pull requests, or suggest new features. Here's how you can contribute:
 
 - Fork the repository.
 - Create a new branch for your feature or fix.
 - Make your changes.
 - Submit a pull request.
+
+## License
+
+```
+Copyright 2024 Qamar Safadi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
 
 
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,5 +69,5 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 
-    implementation(project(":jetpackperformancescanner"))
+    implementation(libs.compose.tracker)
 }

--- a/app/src/main/java/com/qamar/jetpackcomposscanner/MainActivity.kt
+++ b/app/src/main/java/com/qamar/jetpackcomposscanner/MainActivity.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.qamar.composescanner.trackRecompositions
+import com.qamar.composescanner.trackRecompositionsIf
 import com.qamar.jetpackcomposscanner.ui.theme.JetpackComposScannerTheme
 
 class MainActivity : ComponentActivity() {
@@ -112,25 +112,4 @@ fun RecompositionItem(
             style = MaterialTheme.typography.bodyLarge
         )
     }
-}
-
-/**
- * Conditionally tracks recompositions of a Composable, useful for debugging in development.
- *
- * Usage:
- * ```kotlin
- * Modifier.trackRecompositionsIf()
- * Modifier.trackRecompositionsIf(enabled = true)
- * ```
- *
- * @param enabled Whether recomposition tracking should be applied. Default is `false`.
- * You can pass `BuildConfig.DEBUG` or use your own runtime flag.
- *
- * @return The original Modifier if disabled, or a recomposition-tracking Modifier if enabled.
- */
-@Composable
-fun Modifier.trackRecompositionsIf(
-    enabled: Boolean = BuildConfig.DEBUG
-): Modifier {
-    return if (enabled) this.trackRecompositions() else this
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,11 +10,13 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.caching=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Enables namespacing of each library's R class so that its R class includes only the

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.5.2"
+composeTracker = "1.0.0"
 kotlin = "1.9.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -15,6 +16,7 @@ ui = "1.7.5"
 uiTooling = "1.7.5"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+compose-tracker = { module = "io.github.qamarelsafadi:compose-tracker", version.ref = "composeTracker" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/jetpackperformancescanner/build.gradle.kts
+++ b/jetpackperformancescanner/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.android)
     id("maven-publish")
+    id("signing")
     id("com.vanniktech.maven.publish") version "0.29.0"
 }
 
@@ -52,4 +53,42 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+}
+
+// Maven Central Publishing Configuration
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
+    
+    signAllPublications()
+    
+    coordinates("io.github.qamarelsafadi", "compose-tracker", "1.0.0")
+    
+    pom {
+        name.set("Jetpack Compose Tracker")
+        description.set("A simple tool to track UI recompositions in real-time for Jetpack Compose. Helps visualize and measure how often your components are recomposed.")
+        inceptionYear.set("2024")
+        url.set("https://github.com/qamarelsafadi/JetpackComposeTracker/")
+        
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        
+        developers {
+            developer {
+                id.set("qamarelsafadi")
+                name.set("Qamar Safadi")
+                url.set("https://github.com/qamarelsafadi/")
+            }
+        }
+        
+        scm {
+            url.set("https://github.com/qamarelsafadi/JetpackComposeTracker/")
+            connection.set("scm:git:git://github.com/qamarelsafadi/JetpackComposeTracker.git")
+            developerConnection.set("scm:git:ssh://git@github.com/qamarelsafadi/JetpackComposeTracker.git")
+        }
+    }
 }

--- a/jetpackperformancescanner/src/main/java/com/qamar/composescanner/TrackerModifier.kt
+++ b/jetpackperformancescanner/src/main/java/com/qamar/composescanner/TrackerModifier.kt
@@ -50,3 +50,23 @@ fun Modifier.trackRecompositions(): Modifier {
         .border(2.dp, Color.Red)
         .padding(16.dp)
 }
+
+/**
+ * Conditionally tracks recompositions of a Composable, useful for debugging in development.
+ *
+ * Usage:
+ * ```kotlin
+ * Modifier.trackRecompositionsIf()
+ * Modifier.trackRecompositionsIf(enabled = true)
+ * Modifier.trackRecompositionsIf(enabled = BuildConfig.DEBUG)
+ * ```
+ *
+ * @param enabled Whether recomposition tracking should be applied. Default is `false`.
+ * You can pass `BuildConfig.DEBUG` or use your own runtime flag.
+ *
+ * @return The original Modifier if disabled, or a recomposition-tracking Modifier if enabled.
+ */
+@Composable
+fun Modifier.trackRecompositionsIf(enabled: Boolean = false): Modifier {
+    return if (enabled) this.trackRecompositions() else this
+}


### PR DESCRIPTION
## 🎯 Overview
This PR prepares and configures the **Jetpack Compose Tracker** library for publication to Maven Central. This library provides real-time UI recomposition tracking for Jetpack Compose applications, helping developers identify performance bottlenecks and optimize their UI. #4 

## What's New
- **Maven Central Publication Setup**: Complete publication configuration using `com.vanniktech.maven.publish` plugin
- **Documentation**: Updated README with installation and usage instructions

## Key Features
- **Real-time Recomposition Tracking**: Visual feedback when composables recompose
- **Live Recomposition Counter**: Shows exact count of recompositions per component
- **Production-Safe Debugging**: `trackRecompositionsIf()` modifier for conditional tracking
- **Visual Indicators**: Red borders and recomposition count overlays
- **Easy Integration**: Simple modifier-based API

## Library Details
- **Group ID**: `io.github.qamarelsafadi`
- **Artifact ID**: `compose-tracker` 
- **Version**: `1.0.0`
- **Min SDK**: 24
- **Target SDK**: 35

### Library Implementation
The core `TrackerModifier.kt` provides:
```kotlin
// Always track recompositions
Modifier.trackRecompositions()

// Conditionally track (production-safe)
Modifier.trackRecompositionsIf(enabled = BuildConfig.DEBUG)
```

## 📱 Usage Example
```kotlin
@Composable
fun MyComposable() {
    Text(
        text = "Hello World",
        modifier = Modifier
            .trackRecompositionsIf(BuildConfig.DEBUG) // Only in debug builds
            .padding(16.dp)
    )
}
```